### PR TITLE
Fix links and dangerous construction

### DIFF
--- a/benzina/src/typed_uuid.rs
+++ b/benzina/src/typed_uuid.rs
@@ -91,12 +91,7 @@ macro_rules! typed_uuid {
             $vis struct $name($crate::__private::uuid::Uuid);
 
             impl $name {
-                /// Creates a new typed `Uuid` which does not come from the database.
-                #[must_use]
-                #[cfg(feature = "dangerous-construction")]
-                pub fn dangerous_new(inner: $crate::__private::uuid::Uuid) -> Self {
-                    Self(inner)
-                }
+                $crate::__typed_uuid__impl_dangerous_construction!();
 
                 /// Gets the actual `Uuid`.
                 #[must_use]
@@ -345,6 +340,26 @@ macro_rules! __typed_uuid__forward_from {
             }
         )+
     };
+}
+
+#[macro_export]
+#[doc(hidden)]
+#[cfg(feature = "dangerous-construction")]
+macro_rules! __typed_uuid__impl_dangerous_construction {
+    () => {
+        /// Creates a new typed `Uuid` which does not come from the database.
+        #[must_use]
+        pub fn dangerous_new(inner: $crate::__private::uuid::Uuid) -> Self {
+            Self(inner)
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+#[cfg(not(feature = "dangerous-construction"))]
+macro_rules! __typed_uuid__impl_dangerous_construction {
+    () => {};
 }
 
 #[macro_export]

--- a/benzina/src/typed_uuid.rs
+++ b/benzina/src/typed_uuid.rs
@@ -91,18 +91,14 @@ macro_rules! typed_uuid {
             $vis struct $name($crate::__private::uuid::Uuid);
 
             impl $name {
-                /// Creates a new typed [`Uuid`] which does not come from the database.
-                ///
-                /// [`Uuid`]: $crate::__private::uuid::Uuid
+                /// Creates a new typed `Uuid` which does not come from the database.
                 #[must_use]
                 #[cfg(feature = "dangerous-construction")]
                 pub fn dangerous_new(inner: $crate::__private::uuid::Uuid) -> Self {
                     Self(inner)
                 }
 
-                /// Gets the actual [`Uuid`].
-                ///
-                /// [`Uuid`]: $crate::__private::uuid::Uuid
+                /// Gets the actual `Uuid`.
                 #[must_use]
                 pub fn get(&self) -> $crate::__private::uuid::Uuid {
                     self.0


### PR DESCRIPTION
- The `$crate` is obviously not resolved in the docstrings (blame me :sweat: )
- The resolution of the feature must be made _outside_ the implementation macro