### PR TITLE
Implement borrow trait for typed uuid

### DIFF
--- a/benzina/src/typed_uuid.rs
+++ b/benzina/src/typed_uuid.rs
@@ -300,6 +300,12 @@ macro_rules! typed_uuid {
                 }
             }
 
+            impl $crate::__private::std::borrow::Borrow<$crate::__private::uuid::Uuid> for $name {
+                fn borrow(&self) -> &$crate::__private::uuid::Uuid {
+                    &self.0
+                }
+            }
+
             impl $crate::__private::std::convert::From<$name> for $crate::__private::uuid::Uuid {
                 fn from(value: $name) -> Self {
                     value.0


### PR DESCRIPTION
This can be pretty valuable when using a typed UUID as a map key, because you can search in the map using _simple_ UUIDs.