### PR TITLE
Fix visibility of generate fns for typed uuid and allow them to be unused

### DIFF
--- a/benzina/src/typed_uuid.rs
+++ b/benzina/src/typed_uuid.rs
@@ -95,6 +95,7 @@ macro_rules! typed_uuid {
 
                 /// Gets the actual `Uuid`.
                 #[must_use]
+                #[allow(unused)]
                 $vis fn get(&self) -> $crate::__private::uuid::Uuid {
                     self.0
                 }
@@ -366,6 +367,7 @@ macro_rules! __typed_uuid__impl_dangerous_construction {
     ($vis:vis) => {
         /// Creates a new typed `Uuid` which does not come from the database.
         #[must_use]
+        #[allow(unused)]
         $vis fn dangerous_new(inner: $crate::__private::uuid::Uuid) -> Self {
             Self(inner)
         }

--- a/benzina/src/typed_uuid.rs
+++ b/benzina/src/typed_uuid.rs
@@ -91,11 +91,11 @@ macro_rules! typed_uuid {
             $vis struct $name($crate::__private::uuid::Uuid);
 
             impl $name {
-                $crate::__typed_uuid__impl_dangerous_construction!();
+                $crate::__typed_uuid__impl_dangerous_construction!($vis);
 
                 /// Gets the actual `Uuid`.
                 #[must_use]
-                pub fn get(&self) -> $crate::__private::uuid::Uuid {
+                $vis fn get(&self) -> $crate::__private::uuid::Uuid {
                     self.0
                 }
             }
@@ -363,10 +363,10 @@ macro_rules! __typed_uuid__forward_from {
 #[doc(hidden)]
 #[cfg(feature = "dangerous-construction")]
 macro_rules! __typed_uuid__impl_dangerous_construction {
-    () => {
+    ($vis:vis) => {
         /// Creates a new typed `Uuid` which does not come from the database.
         #[must_use]
-        pub fn dangerous_new(inner: $crate::__private::uuid::Uuid) -> Self {
+        $vis fn dangerous_new(inner: $crate::__private::uuid::Uuid) -> Self {
             Self(inner)
         }
     };
@@ -376,7 +376,7 @@ macro_rules! __typed_uuid__impl_dangerous_construction {
 #[doc(hidden)]
 #[cfg(not(feature = "dangerous-construction"))]
 macro_rules! __typed_uuid__impl_dangerous_construction {
-    () => {};
+    ($vis:vis) => {};
 }
 
 #[macro_export]


### PR DESCRIPTION
Without this we could cause some noise with rustc and/or clippy.